### PR TITLE
Relax version constraint on braintree composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "braintree/braintree_php": "2.25.0"
+        "braintree/braintree_php": "~2.25.0"
     },
     "autoload": {
         "psr-0": { "EWZ\\Bundle\\BraintreeBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "braintree/braintree_php": "~2.25.0"
+        "braintree/braintree_php": "2.37.*"
     },
     "autoload": {
         "psr-0": { "EWZ\\Bundle\\BraintreeBundle": "" }


### PR DESCRIPTION
Looks like they follow semantic versioning, and the current version is pretty outdated anyway.  `2.37.*` should therefore be appropriate for most people using this today, I think.